### PR TITLE
allow api_key to be specified in the mailgun_settings instead of only via ENV

### DIFF
--- a/lib/mailgunner/delivery_method.rb
+++ b/lib/mailgunner/delivery_method.rb
@@ -7,13 +7,7 @@ module Mailgunner
     attr_accessor :settings
 
     def initialize(values)
-      @settings = values
-
-      @client = if @settings.has_key?(:domain)
-        Client.new(domain: @settings[:domain])
-      else
-        Client.new
-      end
+      @client = Client.new(values)
     end
 
     def deliver!(mail)

--- a/spec/mailgunner_delivery_method_spec.rb
+++ b/spec/mailgunner_delivery_method_spec.rb
@@ -56,4 +56,16 @@ describe 'Mailgunner::DeliveryMethod' do
 
     ActionMailer::Base.mailgun_settings = {}
   end
+
+  it 'allows the api key to be specified via mailgun settings' do
+    ENV['MAILGUN_API_KEY'] = nil
+
+    stub_request(:post, "#@base_url/#@domain/messages.mime")
+
+    ActionMailer::Base.mailgun_settings = {api_key: 'xxx'}
+
+    ExampleMailer.registration_confirmation(email: @address).deliver
+
+    ActionMailer::Base.mailgun_settings = {}
+  end
 end


### PR DESCRIPTION
We avoid environment variables and just have our infrastructure configuration tools write out config files, this ensures that we can provide the mailgun API key that way instead.  I'm not sure why you weren't always passing through all values from the delivery initialize method, so if there was a good reason for that, let me know and I can change that to be more explicit.
