### PR TITLE
Add support for EU region

### DIFF
--- a/lib/mailgunner/errors.rb
+++ b/lib/mailgunner/errors.rb
@@ -7,6 +7,8 @@ module Mailgunner
 
   class ServerError < Error; end
 
+  class InvalidRegion < Error; end
+
   module NoDomainProvided
     def self.to_s
       raise Error, 'No domain provided'

--- a/spec/mailgunner_delivery_method_spec.rb
+++ b/spec/mailgunner_delivery_method_spec.rb
@@ -18,20 +18,45 @@ describe 'Mailgunner::DeliveryMethod' do
 
     @domain = 'samples.mailgun.org'
 
-    @base_url = 'https://api.mailgun.net/v3'
-
     @auth = ['api', @api_key]
 
     @address = 'user@example.com'
 
     ActionMailer::Base.delivery_method = :mailgun
-
-    ActionMailer::Base.mailgun_settings = {api_key: @api_key, domain: @domain}
   end
 
-  it 'delivers the mail to mailgun in mime format' do
-    stub_request(:post, "#@base_url/#@domain/messages.mime").with(basic_auth: @auth)
+  describe 'for the us region' do
+    before do
+      @base_url = 'https://api.mailgun.net/v3'
 
-    ExampleMailer.registration_confirmation(email: @address).deliver_now
+      ActionMailer::Base.mailgun_settings = {
+        api_key: @api_key,
+        domain: @domain
+      }
+    end
+
+    it 'delivers the mail to mailgun in mime format' do
+      stub_request(:post, "#@base_url/#@domain/messages.mime").with(basic_auth: @auth)
+
+      ExampleMailer.registration_confirmation(email: @address).deliver_now
+    end
+  end
+
+  describe 'for the eu region' do
+    before do
+      @base_url = 'https://api.eu.mailgun.net/v3'
+
+      ActionMailer::Base.mailgun_settings = {
+        api_key: @api_key,
+        domain: @domain,
+        region: 'eu'
+      }
+    end
+
+    it 'delivers the mail to mailgun in mime format' do
+      stub_request(:post, "#@base_url/#@domain/messages.mime").with(basic_auth: @auth)
+
+      ExampleMailer.registration_confirmation(email: @address).deliver_now
+    end
   end
 end

--- a/spec/mailgunner_spec.rb
+++ b/spec/mailgunner_spec.rb
@@ -76,6 +76,33 @@ describe 'Mailgunner::Client' do
     end
   end
 
+  describe 'region method' do
+    it 'defaults to us if nothing was passed along to the constructor' do
+      @client.region.must_equal('us')
+    end
+
+    it 'returns the value passed to the constructor' do
+      client = Mailgunner::Client.new(domain: @domain, api_key: @api_key, region: :eu)
+      client.region.must_equal('eu')
+    end
+
+    it 'defaults to the value of MAILGUN_API_KEY environment variable' do
+      ENV['MAILGUN_REGION'] = 'eu'
+
+      client = Mailgunner::Client.new(domain: @domain, api_key: @api_key)
+      client.region.must_equal('eu')
+
+      ENV.delete('MAILGUN_REGION')
+    end
+
+    it 'raises if region is something else than eu or us' do
+      opts = { domain: @domain, api_key: @api_key, region: :nl }
+
+      exception = proc { Mailgunner::Client.new(opts) }.must_raise(Mailgunner::InvalidRegion)
+      exception.message.must_equal('Region must be "eu" or "us"')
+    end
+  end
+
   describe 'validate_address method' do
     it 'calls the address validate resource with the given email address and returns the response object' do
       stub(:get, "#@base_url/address/validate?address=#@encoded_address")


### PR DESCRIPTION
Since the end of July, Mailgun has introduced their EU region:
https://www.mailgun.com/blog/we-have-a-new-region-in-europe-yall

If you want to use the EU region, you don't need to change much. All you have to do is add a new domain (for example `eu.domainyoualreadyhad.com`) with Mailgun, updater your DNS records, and update the `domain` in your Mailgunner configuration.

But there's one more thing: a different endpoint must be used to send mail through Mailgun's EU region.

This PR adds support to specify that the region could be `eu`, in which case `api.eu.mailgun.net` will be used as endpoint. If no region is specified in the configuration, it is assumed you want to use the original endpoint (`api.mailgun.net`), so nothing breaks for those who update the gem but don't update their configuration. It's also possible to explicitly configure the region to be `us`.

I hope you'll accept this PR soon, or can use it as inspiration. I did my best to adhere to how the gem is currently built. If you have any comments I'd be happy to hear them. Mailgun introducing their EU region helps us greatly to be in compliance with the GDPR.

Thanks!