### PR TITLE
fix(rails): register delivery method before ActionMailer initialization

### DIFF
--- a/lib/mailgunner/railtie.rb
+++ b/lib/mailgunner/railtie.rb
@@ -1,7 +1,7 @@
 module Mailgunner
   # @private
   class Railtie < Rails::Railtie
-    config.before_initialize do
+    initializer 'mailgunner.configure_rails_initialization', before: 'action_mailer.set_configs' do
       require 'mailgunner/delivery_method'
     end
   end


### PR DESCRIPTION
After upgrading from Rails 7 to 7.1 I got an error message saying that `mailgun_settings=` method does not exist. This pull requests fixes that by registering the `mailgun` delivery method before `ActionMailer` setup process. The official `mailgun-ruby` gem had a similar issue in the past as seen here:

- [Don't force ActionMailer to lazy load before configuration.](https://github.com/mailgun/mailgun-ruby/pull/162)