### PR TITLE
Respect smtp_envelope_to when sending MIME messages

### DIFF
--- a/lib/mailgunner/client/messages.rb
+++ b/lib/mailgunner/client/messages.rb
@@ -15,7 +15,7 @@ module Mailgunner
     end
 
     def send_mime(mail)
-      to = ['to', Array(mail.destinations).join(',')]
+      to = ['to', Array(mail.smtp_envelope_to).join(',')]
 
       message = ['message', mail.encoded, {filename: 'message.mime'}]
 

--- a/spec/mailgunner/client_spec.rb
+++ b/spec/mailgunner/client_spec.rb
@@ -131,6 +131,22 @@ RSpec.describe Mailgunner::Client do
 
       client.send_mime(mail)
     end
+
+    it 'overrides recipients with smtp_envelope_to when present' do
+      mail.to = 'alice@example.com, john@example.com'
+      mail.cc = 'carol@example.com, eve@example.com'
+      mail.bcc = 'dave@example.com, frank@example.com'
+
+      mail.smtp_envelope_to = 'alice@example.com, carol@example.com, dave@example.com'
+
+      stub(:post, "#{base_url}/v3/#{domain}/messages.mime")
+
+      recipients = 'alice@example.com, carol@example.com, dave@example.com'
+
+      Net::HTTP::Post.any_instance.expects(:set_form).with(includes(['to', recipients]), 'multipart/form-data')
+
+      client.send_mime(mail)
+    end
   end
 
   describe '#delete_message' do


### PR DESCRIPTION
## Summary

`send_mime` now uses `mail.smtp_envelope_to` as the `to` parameter
when posting to the Mailgun API.

## Behavior

- When `smtp_envelope_to` is **not** explicitly set, it defaults to all
  recipients (`to` + `cc` + `bcc`) — existing behavior is preserved.
- When `smtp_envelope_to` **is** explicitly set, only those addresses
  are used as the SMTP envelope recipients, regardless of the `To`,
  `Cc`, and `Bcc` headers in the MIME message body.

## Use case

This allows callers to control exactly which addresses receive the
email at the transport level, independently of the visible headers —
useful for mailing lists, redirects, or BCC-only delivery scenarios.
